### PR TITLE
Improve elixpo about projects responsive 138

### DIFF
--- a/art.elixpo/CSS/auth/mobileResponsive.css
+++ b/art.elixpo/CSS/auth/mobileResponsive.css
@@ -32,21 +32,27 @@
     }
     .form_login
     {
-        left: 40%;
+        left: 50%;
         transform-origin: center;
-        transform: scale(0.8) translateX(-50%) translateY(-50%);
+        transform: scale(0.95) translateX(-50%) translateY(-50%);
+        width: 90%;
+        max-width: 420px;
     }
     .form_register
     {
-        left: 40%;
+        left: 50%;
         transform-origin: center;
-        transform: scale(0.8) translateX(-50%) translateY(-50%);
+        transform: scale(0.95) translateX(-50%) translateY(-50%);
+        width: 90%;
+        max-width: 420px;
     }
     .form_logout
     {
-        left: 40%;
+        left: 50%;
         transform-origin: center;
-        transform: scale(0.8) translateX(-50%) translateY(-50%);
+        transform: scale(0.95) translateX(-50%) translateY(-50%);
+        width: 90%;
+        max-width: 420px;
     }
     .appName
     {

--- a/art.elixpo/CSS/auth/signIn.css
+++ b/art.elixpo/CSS/auth/signIn.css
@@ -21,6 +21,9 @@
     font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, 'Open Sans', 'Helvetica Neue', sans-serif;
     border: 2px solid #2d79f3;
     transition: 0.25s;
+    opacity: 0;
+    transform-origin: center;
+    animation: formFadeIn 600ms ease-out forwards;
 }
 .form_login.hidden
 {
@@ -149,6 +152,28 @@
     transition: 0.25s;
 }
 
+.form_login .button-submit.is-loading,
+.form_login .btn.is-loading {
+    pointer-events: none;
+    opacity: 0.7;
+    position: relative;
+}
+
+.form_login .button-submit.is-loading::after,
+.form_login .btn.is-loading::after {
+    content: "";
+    position: absolute;
+    right: 12px;
+    top: 50%;
+    width: 16px;
+    height: 16px;
+    border: 2px solid rgba(255,255,255,0.7);
+    border-top-color: transparent;
+    border-radius: 50%;
+    transform: translateY(-50%);
+    animation: spin 0.8s linear infinite;
+}
+
 .form_login .p {
     text-align: center;
     color: #E0E0E0; /* Light text color */
@@ -216,4 +241,20 @@
     font-size: 20px;
     transform: translateX(-50%);
     font-family: 'Source Code Pro', monospace;
+}
+
+@keyframes formFadeIn {
+    from {
+        transform: translateX(-50%) translateY(-55%);
+        opacity: 0;
+    }
+    to {
+        transform: translateX(-50%) translateY(-50%);
+        opacity: 1;
+    }
+}
+
+@keyframes spin {
+    from { transform: translateY(-50%) rotate(0deg); }
+    to { transform: translateY(-50%) rotate(360deg); }
 }

--- a/art.elixpo/CSS/auth/userGuestLogin.css
+++ b/art.elixpo/CSS/auth/userGuestLogin.css
@@ -14,6 +14,8 @@
     overflow: hidden;
     width: 100%;
     /* display: none; */
+    opacity: 0;
+    animation: fadeInOverlay 250ms ease-out forwards;
 }
 .userNameGuest.hidden
 {
@@ -258,6 +260,9 @@
     z-index: 10;
     pointer-events: none;
 }
+.usernameGuestInput:focus {
+    outline: 2px solid #1b97f0;
+}
 .usernameGuestInput::placeholder
 {
     color: #1b97f0;
@@ -265,4 +270,9 @@
     font-weight: 700;
     font-size: 1em;
     font-family: "VT323", monospace;
+}
+
+@keyframes fadeInOverlay {
+  from { opacity: 0; }
+  to { opacity: 1; }
 }

--- a/art.elixpo/JS/auth/login_with_gitHub.js
+++ b/art.elixpo/JS/auth/login_with_gitHub.js
@@ -1,5 +1,8 @@
 
 document.getElementById("signin_with_github").addEventListener("click", () => {
+    const btn = document.getElementById("signin_with_github");
+    if (btn.classList.contains("is-loading")) return;
+    btn.classList.add("is-loading");
     var provider = new firebase.auth.GithubAuthProvider();
 
     firebase.auth().signInWithPopup(provider)
@@ -7,7 +10,7 @@ document.getElementById("signin_with_github").addEventListener("click", () => {
         var token = result.credential.accessToken;
         var user = result.user;
 
-        var docRef = db.collection("users").doc(user.displayName);
+        var docRef = db.collection("users").doc(user.displayName.toLowerCase());
         var today  = new Date();
         var date = today.getDate() + "/" + (today.getMonth()+1) + "/" + today.getFullYear() ; //gives the  current date to the system
         docRef.get().then((doc) => { // gets the whole data against the entered email address
@@ -16,7 +19,7 @@ document.getElementById("signin_with_github").addEventListener("click", () => {
                 if(doc.data().isDev == "DEV")
                     {
                         notify("Login Successful!");
-                        localStorage.setItem("ElixpoAIUser", usernameSignIn);
+                        localStorage.setItem("ElixpoAIUser", user.displayName.toLowerCase());
                         setTimeout(() => {
                             localStorage.setItem("guestLogin", "false");
 
@@ -52,7 +55,7 @@ document.getElementById("signin_with_github").addEventListener("click", () => {
                     user_logo: user.photoURL,
                 }).then(() => {
                     
-                    localStorage.setItem("ElixpoAIUser", user.displayName);
+                    localStorage.setItem("ElixpoAIUser", user.displayName.toLowerCase());
                     localStorage.setItem("guestLogin", "false");
                     redirectTo("src/create");
                 })
@@ -81,6 +84,7 @@ document.getElementById("signin_with_github").addEventListener("click", () => {
         }
         
     });
+    btn.classList.remove("is-loading");
     
 });
 

--- a/art.elixpo/JS/auth/login_with_google.js
+++ b/art.elixpo/JS/auth/login_with_google.js
@@ -1,6 +1,9 @@
 
 
 document.getElementById("signin_with_google").addEventListener("click", () => {
+    const btn = document.getElementById("signin_with_google");
+    if (btn.classList.contains("is-loading")) return;
+    btn.classList.add("is-loading");
     var provider = new firebase.auth.GoogleAuthProvider();
 
     firebase.auth().signInWithPopup(provider)
@@ -9,13 +12,13 @@ document.getElementById("signin_with_google").addEventListener("click", () => {
         var user = result.user;
         var today  = new Date();
         var date = today.getDate() + "/" + (today.getMonth()+1) + "/" + today.getFullYear() ; //gives the  current date to the system
-        var docRef = db.collection("users").doc(user.displayName);
+        var docRef = db.collection("users").doc(user.displayName.toLowerCase());
 
         docRef.get().then((doc) => { // gets the whole data against the entered email address
             if (doc.exists) {
                 tileFlash();
                         notify("Login Successful!");
-                        localStorage.setItem("ElixpoAIUser", usernameSignIn);
+                        localStorage.setItem("ElixpoAIUser", user.displayName.toLowerCase());
                         setTimeout(() => {
                             localStorage.setItem("guestLogin", "false");
                         const urlParams = new URLSearchParams(window.location.search);
@@ -46,7 +49,7 @@ document.getElementById("signin_with_google").addEventListener("click", () => {
                     user_logo: user.photoURL,
                 }).then(() => {
                     
-                    localStorage.setItem("ElixpoAIUser", user.displayName);
+                    localStorage.setItem("ElixpoAIUser", user.displayName.toLowerCase());
                     localStorage.setItem("guestLogin", "false");
                     redirectTo("src/create");
                 })
@@ -75,6 +78,7 @@ document.getElementById("signin_with_google").addEventListener("click", () => {
         }
         
     });
+    btn.classList.remove("is-loading");
     
 });
 

--- a/art.elixpo/JS/auth/signInUpEmail.js
+++ b/art.elixpo/JS/auth/signInUpEmail.js
@@ -11,6 +11,9 @@ var passwordSignIn = document.getElementById("signInPassword").value.toLowerCase
 
 
 document.getElementById("signupBtnDB").addEventListener("click", () => { //when the signup button is clicked
+    const btn = document.getElementById("signupBtnDB");
+    if (btn.classList.contains("is-loading")) return;
+    btn.classList.add("is-loading");
     emailSignUp = document.getElementById("signupEmail").value.trim();
     passwordSignUp = document.getElementById("signupPsswd").value.trim();
     ConfpasswordSignUp = document.getElementById("signupPsswdConf").value.trim();
@@ -19,18 +22,22 @@ document.getElementById("signupBtnDB").addEventListener("click", () => { //when 
     if(emailSignUp == "" || passwordSignUp == "" || ConfpasswordSignUp == "" || userSignUp == "")
     {
         RegisterError("Please Fill All Fields!");
+        btn.classList.remove("is-loading");
     }
     else if(!regex.test(emailSignUp))
     {
         RegisterError("Invalid Email!");
+        btn.classList.remove("is-loading");
     }
     else if(passwordSignUp.length < 6)
     {
         RegisterError("Password Must be 6 Characters Long!");
+        btn.classList.remove("is-loading");
     }
     else if(passwordSignUp != ConfpasswordSignUp)
     {
         RegisterError("Password Doesn't Match!");
+        btn.classList.remove("is-loading");
     }
     else
     {
@@ -39,6 +46,9 @@ document.getElementById("signupBtnDB").addEventListener("click", () => { //when 
 });
 
 document.getElementById("signinBtnDB").addEventListener("click", () => { //when the signin button is clicked
+    const btn = document.getElementById("signinBtnDB");
+    if (btn.classList.contains("is-loading")) return;
+    btn.classList.add("is-loading");
     
     emailSignIn = document.getElementById("signInEmail").value.toLowerCase().trim();
     usernameSignIn = document.getElementById("signInName").value.toLowerCase().trim();
@@ -47,14 +57,17 @@ document.getElementById("signinBtnDB").addEventListener("click", () => { //when 
     if(emailSignIn == "" || passwordSignIn == "" || usernameSignIn == "")
     {
         LoginError("Please Fill All Fields!");
+        btn.classList.remove("is-loading");
     }
     else if(!regex.test(emailSignIn))
     {
         LoginError("Invalid Email!");
+        btn.classList.remove("is-loading");
     }
     else if(passwordSignIn.length < 6)
     {
         LoginError("Password Must be 6 Characters Long!");
+        btn.classList.remove("is-loading");
     }
     else
     {
@@ -105,6 +118,7 @@ function registerUser() {
 
                         document.getElementById("form_register").style.pointerEvents = "all";
                         notify("Please Re Login!");
+                        document.getElementById("signupBtnDB").classList.remove("is-loading");
                         
                     }, 2200);
                     
@@ -113,6 +127,7 @@ function registerUser() {
                     
                     console.error("Error adding document: ", err);
                     RegisterError("Some Error Occured!");
+                    document.getElementById("signupBtnDB").classList.remove("is-loading");
                     setTimeout(() => {
                         
                     }, 500);
@@ -133,6 +148,7 @@ function registerUser() {
             RegisterError("Some Error Occured!");
             
         }
+        document.getElementById("signupBtnDB").classList.remove("is-loading");
         
     });
     
@@ -170,6 +186,11 @@ function loginUser() {
                 LoginError("Invalid Credentials!");
                 
             }
+            document.getElementById("signinBtnDB").classList.remove("is-loading");
+        }
+        else {
+            LoginError("User not found!");
+            document.getElementById("signinBtnDB").classList.remove("is-loading");
         }
 })
 }

--- a/art.elixpo/JS/auth/signInUpGeneral.js
+++ b/art.elixpo/JS/auth/signInUpGeneral.js
@@ -132,6 +132,7 @@ document.getElementById("passwordShowHideSignInPassword").addEventListener("clic
    } else {
        passwordField.setAttribute("type", "password");
    }
+   e.currentTarget.setAttribute("aria-pressed", passwordField.getAttribute("type") === "text" ? "true" : "false");
 });
 
 
@@ -144,6 +145,7 @@ document.getElementById("passwordShowHideSignUpPassword").addEventListener("clic
    } else {
        passwordField.setAttribute("type", "password");
    }
+   e.currentTarget.setAttribute("aria-pressed", passwordField.getAttribute("type") === "text" ? "true" : "false");
 });
 
 
@@ -157,6 +159,7 @@ document.getElementById("passwordShowHideSignUpPasswordConf").addEventListener("
    } else {
        passwordField.setAttribute("type", "password");
    }
+   e.currentTarget.setAttribute("aria-pressed", passwordField.getAttribute("type") === "text" ? "true" : "false");
 });
 
 
@@ -255,7 +258,7 @@ document.getElementById("usernameGuestInput").addEventListener("keypress", async
     
  });
 
-document.getElementById("guestAuth").addEventListener("click", () => {
+document.querySelectorAll(".guestAuth").forEach((btn)=>btn.addEventListener("click", () => {
     document.getElementById("userNameGuest").style.display = "block";
     document.getElementById("initializeText1").innerText = "";
     document.getElementById("initializeText2").innerText = "";
@@ -298,7 +301,7 @@ document.getElementById("guestAuth").addEventListener("click", () => {
        });
     
     }, 1300);
-});
+}));
 
 
 function generateUUID() {

--- a/art.elixpo/src/auth/index.html
+++ b/art.elixpo/src/auth/index.html
@@ -17,7 +17,7 @@
     <link rel="icon" type="image/x-icon" href="https://firebasestorage.googleapis.com/v0/b/videolize-3563f.appspot.com/o/bigstar.png?alt=media&token=53c5945b-2b37-4c3e-972c-7bd1b0b9e4f1">
 </head>
 <body>
-    <div class="container">
+    <div class="container" role="application" aria-label="Elixpo authentication">
       <div class="savedMsg" id="savedMsg">
         <div class="blob1"></div>
         <div class="blob2"></div>
@@ -52,28 +52,28 @@
         <div class="vgGirl"></div>
 
 
-    <form class="form_login" id="form_login">
+    <form class="form_login" id="form_login" role="form" aria-labelledby="signin-heading">
 
       <div class="flex-column">
-        <label>Username </label></div>
+        <label id="signin-heading">Username </label></div>
         <div class="inputForm">
           <ion-icon name="text" class="usernameIcon"></ion-icon>
-          <input type="text" class="input" id="signInName" placeholder="Alex" >
+          <input type="text" class="input" id="signInName" placeholder="Alex" aria-label="Username" autocomplete="username">
         </div>
 
 
         <div class="flex-column">
           <label>Email </label></div>
           <div class="inputForm">
-            <ion-icon name="at" class="emailIcon"></ion-icon>
-            <input type="text" class="input" id="signInEmail" placeholder="someone@gmail.com" >
+          <ion-icon name="at" class="emailIcon"></ion-icon>
+            <input type="email" class="input" id="signInEmail" placeholder="someone@gmail.com" aria-label="Email" autocomplete="email" >
           </div>
         
         <div class="flex-column">
           <label>Password </label></div>
           <div class="inputForm">
             <ion-icon name="lock-closed-outline" class="passwordIcon"></ion-icon>
-            <input type="password" class="input" id="signInPassword" placeholder="Enter your Password">
+            <input type="password" class="input" id="signInPassword" placeholder="Enter your Password" aria-label="Password" autocomplete="current-password">
             <ion-icon name="eye" class="passwordShowHide hidden" id="passwordShowHideSignInPassword"></ion-icon>
           </div>
 
@@ -82,52 +82,52 @@
         <div class="flex-row">
           <span class="span">Forgot password?</span>
         </div>
-        <button class="button-submit" id="signinBtnDB" type="button">Sign In</button>
+        <button class="button-submit" id="signinBtnDB" type="button" aria-label="Sign in">Sign In</button>
         <p class="p">Don't have an account? <span class="span" id="signInFormBtn">Sign Up</span>
     
     
         <div class="flex-row">
-          <button class="btn google" id="signin_with_google" type="button">
+          <button class="btn google" id="signin_with_google" type="button" aria-label="Sign in with Google">
             <ion-icon name="logo-google"></ion-icon>
     </svg>
             Google 
           </button>
           
-          <button class="btn github" id="signin_with_github" type="button">
+          <button class="btn github" id="signin_with_github" type="button" aria-label="Sign in with GitHub">
             <ion-icon name="logo-github"></ion-icon>
     
             Github
-            <p id="LoginError"> </p>
+            <p id="LoginError" aria-live="polite"> </p>
           
     </button>
-    <button class="btn guest" type="button" id="guestAuth">
+    <button class="btn guest guestAuth" type="button" aria-label="Continue as Guest">
       <ion-icon name="person"></ion-icon>
       Guest
-      <p id="RegisterError"></p>
+      <p id="RegisterError" aria-live="polite"></p>
 </button>
   </div></form>
 
 
-    <form class="form_register hidden" id="form_register">
+    <form class="form_register hidden" id="form_register" role="form" aria-labelledby="signup-heading">
       <div class="flex-column">
-        <label>Username </label></div>
+        <label id="signup-heading">Username </label></div>
         <div class="inputForm">
           <ion-icon name="text" class="usernameIcon"></ion-icon>
-          <input type="text" class="input" id="signupName" placeholder="Alex">
+          <input type="text" class="input" id="signupName" placeholder="Alex" aria-label="Username" autocomplete="username">
         </div>
 
       <div class="flex-column">
         <label>Email </label></div>
         <div class="inputForm">
           <ion-icon name="at" class="emailIcon"></ion-icon>
-          <input type="text" class="input" id="signupEmail" placeholder="someone@gmail.com">
+          <input type="email" class="input" id="signupEmail" placeholder="someone@gmail.com" aria-label="Email" autocomplete="email">
         </div>
       
       <div class="flex-column">
         <label>Password </label></div>
         <div class="inputForm">
           <ion-icon name="lock-closed-outline" class="passwordIcon"></ion-icon>
-          <input type="password" class="input" id="signupPsswd" placeholder="Enter your Password">
+          <input type="password" class="input" id="signupPsswd" placeholder="Enter your Password" aria-label="Password" autocomplete="new-password">
           <ion-icon name="eye" class="passwordShowHide" id="passwordShowHideSignUpPassword"></ion-icon>
         </div>
 
@@ -135,33 +135,33 @@
           <label>Confirm Password </label></div>
           <div class="inputForm">
             <ion-icon name="lock-closed-outline" class="passwordIcon"></ion-icon>
-            <input type="password" class="input" id="signupPsswdConf" placeholder="Confirm your Password">
+            <input type="password" class="input" id="signupPsswdConf" placeholder="Confirm your Password" aria-label="Confirm Password" autocomplete="new-password">
             <ion-icon name="eye" class="passwordShowHide" id="passwordShowHideSignUpPasswordConf"></ion-icon>
           </div>
 
         
 
-      <button class="button-submit" id="signupBtnDB" type="button">Sign Up</button>
+      <button class="button-submit" id="signupBtnDB" type="button" aria-label="Sign up">Sign Up</button>
       <p class="p"> Have an account? <span class="span" id="signUpFormBtn">Sign In</span>
   
   
       <div class="flex-row">
-        <button class="btn google">
+        <button class="btn google" type="button" aria-label="Continue with Google">
           <ion-icon name="logo-google"></ion-icon>
   </svg>
           Google 
         </button>
         
-        <button class="btn github">
+        <button class="btn github" type="button" aria-label="Continue with GitHub">
           <ion-icon name="logo-github"></ion-icon>
   
           Github
-          <p id="RegisterError"></p>
+          <p id="RegisterError" aria-live="polite"></p>
       </button>
-      <button class="btn guest" type="button" id="guestAuth">
+      <button class="btn guest guestAuth" type="button" aria-label="Continue as Guest">
         <ion-icon name="person"></ion-icon>
         Guest
-        <p id="RegisterError"></p>
+        <p id="RegisterError" aria-live="polite"></p>
   </button>
       
 

--- a/elixpo/about/index.html
+++ b/elixpo/about/index.html
@@ -17,10 +17,10 @@
     <body class="relative min-h-screen min-w-screen bg-white overflow-hidden items-center">
       <canvas id="above-canvas"></canvas> 
         <div class="absolute top-0 left-0 w-screen h-screen opacity-55 bg-[url('../CSS/ASSESTS/paperTexture.jpg')] bg-contain bg-repeat bg-center brightness-[55%] sepia-[65%] "></div>
-        <div class="navBar static h-[80px] flex items-center justify-between border-b-2 border-[#888] px-[50px] box-border mb-[5px]">
-          <p class="location text-[1.5em] z-10">WB,IN</p>
-          <p id="rootRedirect"  class="name text-[3em] cursor-pointer z-10"> Elixpo </p>
-          <ion-icon name="list" class="cursor-pointer" id="scrollInMenu"></ion-icon>
+        <div class="navBar static h-[64px] md:h-[80px] flex items-center justify-between border-b-2 border-[#888] px-4 md:px-[50px] box-border mb-[5px]">
+          <p class="location text-[1.1em] md:text-[1.5em] z-10">WB,IN</p>
+          <p id="rootRedirect"  class="name text-[2em] md:text-[3em] cursor-pointer z-10"> Elixpo </p>
+          <ion-icon name="list" class="cursor-pointer text-[1.5em] md:text-[2em]" id="scrollInMenu"></ion-icon>
         </div>
 
         <div id="menuSection" class=" hidden menuSection bg-[#1D1D1B] h-full w-full fixed top-0 left-0 z-50 flex flex-col items-center justify-center gap-5 text-[#E2D9C8] text-[2em] font-extrabold tracking-widest">
@@ -36,42 +36,42 @@
       
         </div>
       
-        <div id="appContainer" class="appContainer relative top-0 mx-auto w-full max-w-[1440px] h-[calc(100vh-100px)] max-h-[calc(100vh-100px)]  overflow-y-auto overflow-x-hidden p-10" >
-            <section class="introSection flex flex-row item-center gap-10">
+        <div id="appContainer" class="appContainer relative top-0 mx-auto w-full max-w-[1440px] h-[calc(100vh-100px)] max-h-[calc(100vh-100px)]  overflow-y-auto overflow-x-hidden p-4 md:p-10" >
+            <section class="introSection flex flex-col md:flex-row item-center gap-6 md:gap-10">
 
-                <div class="col1 flex flex-col justify-left gap-2 w-1/2">
-                    <div class="headingText text-[7em] flex-start w-[500px] p-5 h-[200px] flex justify-center items-center bg-[#1B1B19] text-center opacity-90 select-none rounded-[15px] tracking-[5px]">
+                <div class="col1 flex flex-col justify-left gap-2 w-full md:w-1/2">
+                    <div class="headingText text-[3.5em] sm:text-[5em] lg:text-[7em] flex-start w-full md:w-[500px] p-4 md:p-5 h-[120px] sm:h-[160px] md:h-[200px] flex justify-center items-center bg-[#1B1B19] text-center opacity-90 select-none rounded-[15px] tracking-[2px] md:tracking-[5px]">
                         <p class="text-[#E2D9C8] transform scale-y-[1.4] font-extrabold">AYUSHMAN</p>
                       </div>
-                      <div class="headingText text-[7em] flex-start w-[400px] p-5 h-[200px] flex justify-center items-center bg-[#1B1B19] text-center opacity-90 select-none rounded-[15px] tracking-[7px]">
+                      <div class="headingText text-[3.5em] sm:text-[5em] lg:text-[7em] flex-start w-full md:w-[400px] p-4 md:p-5 h-[120px] sm:h-[160px] md:h-[200px] flex justify-center items-center bg-[#1B1B19] text-center opacity-90 select-none rounded-[15px] tracking-[3px] md:tracking-[7px]">
                         <p class="text-[#E2D9C8] transform scale-y-[1.4] font-extrabold">ABOUT!</p>
                       </div>
                       <div class="descriptionText">
-                        <p class="text-[#1B1B19] text-[2em]">Elixpo is a platform dedicated to exploring the intersection of technology and creativity, offering insights into innovative projects and research.
+                        <p class="text-[#1B1B19] text-[1.1em] sm:text-[1.3em] md:text-[1.6em] lg:text-[2em]">Elixpo is a platform dedicated to exploring the intersection of technology and creativity, offering insights into innovative projects and research.
                            Alongside I am an Ex-Web Dev Associate @GDG JISU | DevOps Engineer @pollinations | Excellence SOF NCO 19' | 3rd, 2nd SOF NCO 14' 18' | LSA exe.BIT Runners 20' | Techverse2.0 & 3.0 Winner | Mod Dev @modrinth.
                            More about me, as you scroll down this page! Thanks for visiting my portfolio!
                         </p>
                       </div>
                 </div>
-                <div class="col2 bg-[url(../CSS/ASSESTS/about/ptr-11.png)] bg-cover bg-center h-[750px] w-1/2 rounded-[10px] sepia-[65%] saturate-[200%] border-2 border-[#222]"></div>
+                <div class="col2 bg-[url(../CSS/ASSESTS/about/ptr-11.png)] bg-cover bg-center h-[320px] sm:h-[480px] md:h-[600px] lg:h-[750px] w-full md:w-1/2 rounded-[10px] sepia-[65%] saturate-[200%] border-2 border-[#222]"></div>
             </section>
 
             <section  id="workExperience" class="workExperience relative h-[600px] mb-[20px] pl-[40px] pr-[40px] box-border py-[40px] gap-[20px] overflow-x-auto overflow-y-hidden flex-nowrap flex flex-row mt-20 select-none cursor-grabbing">
             </section>
 
-            <section  class="visitPublication flex flex-row gap-10 justify-between p-20 mt-5">
-                <p class="publicationText text-[#222] text-[6em] transform scale-y-[1.2] font-extrabold" > PUBLICATIONS </p>
+            <section  class="visitPublication flex flex-col md:flex-row gap-6 md:gap-10 justify-between p-6 md:p-12 lg:p-20 mt-5">
+                <p class="publicationText text-[#222] text-[3em] sm:text-[4em] lg:text-[6em] transform scale-y-[1.2] font-extrabold" > PUBLICATIONS </p>
 
-                <div id="publicationVisit" class="visitCircle w-[350px] h-[100px] text-[3em] border-2 border-[#222] rounded-full mt-10 flex justify-center items-center cursor-pointer transition-all duration-300 hover:bg-[#1B1B19] hover:text-[#E2D9C8] hover:scale-105">
+                <div id="publicationVisit" class="visitCircle w-full md:w-[350px] h-[70px] md:h-[100px] text-[1.8em] md:text-[3em] border-2 border-[#222] rounded-full mt-4 md:mt-10 flex justify-center items-center cursor-pointer transition-all duration-300 hover:bg-[#1B1B19] hover:text-[#E2D9C8] hover:scale-105">
                   Visit Now
                 </div>
 
             </section>
 
 
-            <section class="aboutSectionImages mt-5 p-10 flex flex-row gap-[5px]">
-                <div class="bg-[url(../CSS/ASSESTS/about/sq-22.png)] bg-cover bg-center h-[750px] w-1/2 rounded-[10px] sepia-[65%] saturate-[200%] border-2 border-[#222]"></div>
-                <div class="bg-[url(../CSS/ASSESTS/about/sq-11.png)] bg-cover bg-center h-[750px] w-1/2 rounded-[10px] sepia-[65%] saturate-[200%] border-2 border-[#222]"></div>
+            <section class="aboutSectionImages mt-5 p-4 md:p-10 flex flex-col md:flex-row gap-[5px]">
+                <div class="bg-[url(../CSS/ASSESTS/about/sq-22.png)] bg-cover bg-center h-[320px] sm:h-[480px] md:h-[600px] lg:h-[750px] w-full md:w-1/2 rounded-[10px] sepia-[65%] saturate-[200%] border-2 border-[#222]"></div>
+                <div class="bg-[url(../CSS/ASSESTS/about/sq-11.png)] bg-cover bg-center h-[320px] sm:h-[480px] md:h-[600px] lg:h-[750px] w-full md:w-1/2 rounded-[10px] sepia-[65%] saturate-[200%] border-2 border-[#222]"></div>
             </section>
 
 
@@ -120,7 +120,7 @@
                   
                   
             </section>
-            <section id="spotlight" class="spotlight relative h-[350px] mb-[20px] pl-[40px] pr-[40px] box-border py-[40px] gap-[20px] overflow-x-auto overflow-y-hidden flex-nowrap flex flex-row select-none cursor-grabbing">
+            <section id="spotlight" class="spotlight relative h-[260px] sm:h-[300px] md:h-[350px] mb-[20px] pl-4 md:pl-[40px] pr-4 md:pr-[40px] box-border py-[20px] md:py-[40px] gap-[20px] overflow-x-auto overflow-y-hidden flex-nowrap flex flex-row select-none cursor-grabbing">
             </section>
 
             <section class="contactMeWrapper overflow-hidden w-full border-y-2 border-[#111] mt-10 pt-5 pb-5 justify-center select-none overflow-y-hidden cursor-pointer">
@@ -138,9 +138,9 @@
               </section>
 
               <footer class="w-screen left-1/2 -translate-x-1/2 relative">
-                <div class="footerContent flex flex-row justify-around mt-5 h-[40px] w-full items-left">
-                  <p class="footerName select-none text-[#111] text-[3em]"> ELIXPO </p>
-                  <div class="socials flex flex-row gap-5 mt-5 h-full items-center">
+                <div class="footerContent flex flex-col md:flex-row justify-around mt-5 h-auto md:h-[40px] w-full items-left px-4 md:px-0">
+                  <p class="footerName select-none text-[#111] text-[2em] md:text-[3em]"> ELIXPO </p>
+                  <div class="socials flex flex-row gap-5 mt-3 md:mt-5 h-full items-center">
                     <ion-icon name="logo-github" class="socialIcon text-[2em] cursor-pointer hover:rotate-[10deg] transition-[0.25s]"></ion-icon>
                     <div class="spacer h-[10px] w-[10px] rounded-[50%] bg-[#111]"></div>
                     <ion-icon name="logo-linkedin" class="socialIcon text-[2em] cursor-pointer hover:rotate-[10deg] transition-[0.25s]"></ion-icon>

--- a/elixpo/projects/index.html
+++ b/elixpo/projects/index.html
@@ -17,10 +17,10 @@
 <body class="relative min-h-screen bg-white overflow-hidden">
     <canvas id="above-canvas"></canvas> 
   <div class="absolute top-0 left-0 w-screen h-screen opacity-55 bg-[url('../CSS/ASSESTS/paperTexture.jpg')] bg-contain bg-repeat bg-center brightness-[55%] sepia-[65%] "></div>
-  <div class="navBar static h-[80px] flex items-center justify-between border-b-2 border-[#888] px-[50px] box-border mb-[5px]">
-    <p class="location text-[1.5em] z-10">WB,IN</p>
-    <p id="rootRedirect"  class="name text-[3em] cursor-pointer z-10"> Elixpo </p>
-    <ion-icon name="list" class="cursor-pointer" id="scrollInMenu"></ion-icon>
+  <div class="navBar static h-[64px] md:h-[80px] flex items-center justify-between border-b-2 border-[#888] px-4 md:px-[50px] box-border mb-[5px]">
+    <p class="location text-[1.1em] md:text-[1.5em] z-10">WB,IN</p>
+    <p id="rootRedirect"  class="name text-[2em] md:text-[3em] cursor-pointer z-10"> Elixpo </p>
+    <ion-icon name="list" class="cursor-pointer text-[1.5em] md:text-[2em]" id="scrollInMenu"></ion-icon>
   </div>
 
   <div id="menuSection" class=" hidden menuSection bg-[#1D1D1B] h-full w-full fixed top-0 left-0 z-50 flex flex-col items-center justify-center gap-5 text-[#E2D9C8] text-[2em] font-extrabold tracking-widest">
@@ -36,18 +36,18 @@
 
   </div>
 
-    <div id="appContainer" class="appContainer relative top-0 mx-auto max-w-[1440px] h-[calc(100vh-100px)] max-h-[calc(100vh-100px)]  overflow-y-auto overflow-x-hidden p-10" >
+    <div id="appContainer" class="appContainer relative top-0 mx-auto max-w-[1440px] h-[calc(100vh-100px)] max-h-[calc(100vh-100px)]  overflow-y-auto overflow-x-hidden p-4 md:p-10" >
 
-        <div class="headerTextContainer w-full p-2 flex h-[200px] flex-row justify-left gap-10">
-        <div class="projectsHeaderText text-[10em] lg:text-[9em] w-1/2 flex justify-center items-center bg-[#1B1B19] text-center opacity-90 select-none rounded-[15px] tracking-[5px]">
+        <div class="headerTextContainer w-full p-2 flex h-auto md:h-[200px] flex-col md:flex-row justify-left gap-4 md:gap-10">
+        <div class="projectsHeaderText text-[3.5em] sm:text-[6em] md:text-[8em] lg:text-[9em] w-full md:w-1/2 flex justify-center items-center bg-[#1B1B19] text-center opacity-90 select-none rounded-[15px] tracking-[2px] md:tracking-[5px]">
             <p class="text-[#E2D9C8]">PROJECTS</p>
           </div>
-          <p class="w-1/2 relative flex-wrap break-words text-[#111] font-bold text-[1.4em]">
+          <p class="w-full md:w-1/2 relative flex-wrap break-words text-[#111] font-bold text-[1em] sm:text-[1.2em] md:text-[1.4em]">
             This page contains some of my projects that I have worked on. You can find the source code and more details about each project by 
             clicking on the project title. Feel free to explore and reach out if you have any questions or would like to collaborate on any of these projects!  
           </p>
         </div>
-        <div class="stampImageHolder absolute top-[150px] left-[42%] bg-[url(../CSS/ASSESTS/projects/stamp-2.png)] bg-center bg-cover h-[150px] w-[150px]"></div>
+        <div class="stampImageHolder absolute top-[150px] left-1/2 -translate-x-1/2 md:left-[42%] md:translate-x-0 bg-[url(../CSS/ASSESTS/projects/stamp-2.png)] bg-center bg-cover h-[100px] w-[100px] md:h-[150px] md:w-[150px]"></div>
 
         <section id="projectsContainer" class="projectsContainer w-full mt-5 border-t-2 border-[#555] flex flex-col gap-10">
         </section>
@@ -67,9 +67,9 @@
           </section>
 
           <footer class="w-screen left-1/2 -translate-x-1/2 relative">
-            <div class="footerContent flex flex-row justify-around mt-5 h-[40px] w-full items-left">
-              <p class="footerName select-none text-[#111] text-[3em]"> ELIXPO </p>
-              <div class="socials flex flex-row gap-5 mt-5 h-full items-center">
+            <div class="footerContent flex flex-col md:flex-row justify-around mt-5 h-auto md:h-[40px] w-full items-left px-4 md:px-0">
+              <p class="footerName select-none text-[#111] text-[2em] md:text-[3em]"> ELIXPO </p>
+              <div class="socials flex flex-row gap-5 mt-3 md:mt-5 h-full items-center">
                 <ion-icon name="logo-github" class="socialIcon text-[2em] cursor-pointer hover:rotate-[10deg] transition-[0.25s]"></ion-icon>
                 <div class="spacer h-[10px] w-[10px] rounded-[50%] bg-[#111]"></div>
                 <ion-icon name="logo-linkedin" class="socialIcon text-[2em] cursor-pointer hover:rotate-[10deg] transition-[0.25s]"></ion-icon>


### PR DESCRIPTION
Objective: Make the /about and /projects pages responsive across sm/md/lg breakpoints while preserving all existing assets and visual identity. Prefer Tailwind utilities; use vanilla CSS only if necessary.
Scope of changes:
About (elixpo/about/index.html)
Responsive navbar: adjusted height/padding and icon/text sizes on sm/md/lg.
Intro section: stacked layout on small screens; fluid typography for headings and body; image panel scales by breakpoint.
Publications CTA: responsive width/height and text sizes.
Spotlight/sections: responsive heights/paddings; improved scroll container spacing on smaller screens.
Footer: stacks vertically on small screens, horizontal on larger screens.
Projects (elixpo/projects/index.html)
Header block: responsive grid (title + description) with fluid type scaling.
Stamp badge: centered on small screens, positioned for md+; size scales by breakpoint.
Container padding: reduced on small screens, expanded on md+.
Footer: stacks vertically on small screens.