### PR TITLE
Add automatic issue labeling workflow

### DIFF
--- a/.github/workflows/Auto_issue_labeling.yml
+++ b/.github/workflows/Auto_issue_labeling.yml
@@ -1,0 +1,42 @@
+name: "Automatic Issue Labeling"
+
+on:
+  issues:
+    types: [opened]
+
+permissions:
+  issues: write
+  contents: read
+
+jobs:
+  label_issue:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Add label automatically
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const { issue, repository } = context.payload;
+            const owner = repository.owner.login;
+            const repo = repository.name;
+            const author = issue.user.login;
+
+            console.log(`Issue #${issue.number} opened by ${author}`);
+
+            const { data: collaborators } = await github.rest.repos.listCollaborators({
+              owner,
+              repo,
+              affiliation: "all"
+            });
+
+            const isCollaborator = collaborators.some(c => c.login === author);
+            const labelToAdd = isCollaborator ? "INTERNAL" : "COMMUNITY";
+
+            await github.rest.issues.addLabels({
+              owner,
+              repo,
+              issue_number: issue.number,
+              labels: [labelToAdd]
+            });
+
+            console.log(`Added label ${labelToAdd} to issue #${issue.number}`);


### PR DESCRIPTION
This pull request introduces a new GitHub Actions workflow that automatically labels newly opened issues as COMMUNITY or INTERNAL, improving issue management and workflow automation.

How It Works

The workflow triggers whenever a new issue is opened.

It checks whether the issue author is a collaborator of the repository.

**If the author is a collaborator/owner, the issue is labeled INTERNAL.
If the author is not a collaborator, the issue is labeled COMMUNITY.**

**_Please chnage the labels on the following code accoring hacktoberfest labeling_**

Implementation Details

Workflow file: .github/workflows/auto-issue-labeling.yml

Uses actions/github-script@v7 to execute API calls.

Requires the GITHUB_TOKEN with issues: write and contents: read permissions.

Labels must exist in the repository prior to use.

Related Issue
 #305

Additional Notes

Tested on forked repository for both collaborator and non-collaborator users.
Enhances repository automation and community contribution visibility.

 I hope this help for this contribution.