### PR TITLE
[Jackey] Update clone and install instructions in README

### DIFF
--- a/jackey.elixpo/README.md
+++ b/jackey.elixpo/README.md
@@ -21,8 +21,8 @@ A Discord bot for generating, remixing, and managing AI-generated images using s
 ### 1. Clone & Install
 
 ```bash
-git clone https://github.com/yourusername/elixpo-discord-bot.git
-cd elixpo-discord-bot
+git clone https://github.com/Circuit-Overtime/elixpo_chapter.git
+cd elixpo_chapter/jackey.elixpo
 npm install
 ```
 


### PR DESCRIPTION
The clone and install instructions before was using placeholder URL. I have changed it to a real one :)